### PR TITLE
[dbnode] add support for snappy compression

### DIFF
--- a/config/m3db/clustered-etcd/generated.yaml
+++ b/config/m3db/clustered-etcd/generated.yaml
@@ -81,6 +81,8 @@
       "handlerPath": "/metrics"
     "samplingRate": 1
     "sanitization": "prometheus"
+  "tchannel":
+    "compression": "snappy"
   "writeNewSeriesAsync": true
   "writeNewSeriesBackoffDuration": "2ms"
   "writeNewSeriesLimitPerSecond": 1048576

--- a/config/m3db/clustered-etcd/m3dbnode.libsonnet
+++ b/config/m3db/clustered-etcd/m3dbnode.libsonnet
@@ -132,6 +132,9 @@ function(cluster, coordinator={}, db={}) {
     },
     "fs": {
       "filePathPrefix": "/var/lib/m3db"
+    },
+    "tchannel": {
+      "compression": "snappy",
     }
   } + db,
 }

--- a/config/m3db/local-etcd/generated.yaml
+++ b/config/m3db/local-etcd/generated.yaml
@@ -78,6 +78,8 @@
       "handlerPath": "/metrics"
     "samplingRate": 1
     "sanitization": "prometheus"
+  "tchannel":
+    "compression": "snappy"
   "writeNewSeriesAsync": true
   "writeNewSeriesBackoffDuration": "2ms"
   "writeNewSeriesLimitPerSecond": 1048576

--- a/config/m3db/local-etcd/m3dbnode.libsonnet
+++ b/config/m3db/local-etcd/m3dbnode.libsonnet
@@ -95,6 +95,9 @@ function(coordinator={}, db={}) {
     "fs": {
       "filePathPrefix": "/var/lib/m3db"
     },
+    "tchannel": {
+      "compression": "snappy",
+    },
     "config": {
       "service": {
         "env": "default_env",

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/RoaringBitmap/roaring v0.4.21
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/aiven/tchannel-go v1.19.0 // indirect
 	github.com/apache/thrift v0.13.0
 	github.com/apex/log v1.3.0 // indirect
 	github.com/bmatcuk/doublestar v1.3.1 // indirect
@@ -156,7 +157,7 @@ replace github.com/prometheus/common => github.com/prometheus/common v0.9.1
 
 replace github.com/uber-go/atomic => go.uber.org/atomic v1.6.0
 
-// Aiven specific: lz4 compressed branch
-replace github.com/uber/tchannel-go => github.com/aiven/tchannel-go v0.0.0-20191121135334-22400d53f905
+// Aiven specific: snappy compressed branch
+replace github.com/uber/tchannel-go => github.com/aiven/tchannel-go aiven
 
 replace github.com/pierrec/lz4 => github.com/pierrec/lz4 v2.5.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,9 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUW
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
-github.com/aiven/tchannel-go v0.0.0-20191121135334-22400d53f905 h1:2PvR/JvPBwTdd79BUXMHPxWiiV4TkYTzbjDZYBbK81g=
-github.com/aiven/tchannel-go v0.0.0-20191121135334-22400d53f905/go.mod h1:TjrPVutwHrlYmlScDxkGdqEpJ/+sj/qRoImjzqTqfGg=
+github.com/aiven/tchannel-go v1.19.0/go.mod h1:TjrPVutwHrlYmlScDxkGdqEpJ/+sj/qRoImjzqTqfGg=
+github.com/aiven/tchannel-go v1.19.1-0.20200910083610-4b39a9179ae1 h1:pdJyQgi14sRuEFlqmy31NjGDkW3WWkLfLeRTBzl/3ro=
+github.com/aiven/tchannel-go v1.19.1-0.20200910083610-4b39a9179ae1/go.mod h1:TjrPVutwHrlYmlScDxkGdqEpJ/+sj/qRoImjzqTqfGg=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -37,6 +37,7 @@ import (
 	"github.com/m3db/m3/src/x/instrument"
 	xlog "github.com/m3db/m3/src/x/log"
 	"github.com/m3db/m3/src/x/opentracing"
+	"github.com/uber/tchannel-go"
 
 	"go.etcd.io/etcd/embed"
 	"go.etcd.io/etcd/pkg/transport"
@@ -577,8 +578,24 @@ func IsSeedNode(initialCluster []environment.SeedNode, hostID string) bool {
 	return false
 }
 
+type compressionMethod tchannel.CompressionMethod
+
+func (cm *compressionMethod) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	if err := unmarshal(&str); err != nil {
+		return err
+	}
+	tcm, err := tchannel.NewCompressionMethod(str)
+	if err != nil {
+		return err
+	}
+	*cm = compressionMethod(tcm)
+	return nil
+}
+
 // TChannelConfiguration holds TChannel config options.
 type TChannelConfiguration struct {
-	MaxIdleTime       time.Duration `yaml:"maxIdleTime"`
-	IdleCheckInterval time.Duration `yaml:"idleCheckInterval"`
+	MaxIdleTime       time.Duration     `yaml:"maxIdleTime"`
+	IdleCheckInterval time.Duration     `yaml:"idleCheckInterval"`
+	Compression       compressionMethod `yaml:"compression"`
 }

--- a/src/dbnode/client/options.go
+++ b/src/dbnode/client/options.go
@@ -307,7 +307,10 @@ func NewOptionsForAsyncClusters(opts Options, topoInits []topology.Initializer, 
 func defaultNewConnectionFn(
 	channelName string, address string, opts Options,
 ) (xclose.SimpleCloser, rpc.TChanNode, error) {
-	channel, err := tchannel.NewChannel(channelName, opts.ChannelOptions())
+	channelOpts := opts.ChannelOptions()
+	// Advertize snappy compression support. It gets used only if remote peer has it enabled.
+	channelOpts.DefaultConnectionOptions.CompressionMethod = tchannel.SnappyCompression
+	channel, err := tchannel.NewChannel(channelName, channelOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -647,6 +647,10 @@ func Run(runOpts RunOptions) {
 	if cfg.TChannel != nil {
 		tchannelOpts.MaxIdleTime = cfg.TChannel.MaxIdleTime
 		tchannelOpts.IdleCheckInterval = cfg.TChannel.IdleCheckInterval
+		tchannelOpts.DefaultConnectionOptions.CompressionMethod = tchannel.CompressionMethod(cfg.TChannel.Compression)
+		if tchannelOpts.DefaultConnectionOptions.CompressionMethod != tchannel.NoCompression {
+			logger.Info("tchannel has compression enabled", zap.String("compression", tchannelOpts.DefaultConnectionOptions.CompressionMethod.String()))
+		}
 	}
 	tchanOpts := ttnode.NewOptions(tchannelOpts).
 		SetInstrumentOptions(opts.InstrumentOptions())

--- a/src/dbnode/x/tchannel/options.go
+++ b/src/dbnode/x/tchannel/options.go
@@ -41,7 +41,8 @@ func NewDefaultChannelOptions() *tchannel.ChannelOptions {
 		MaxIdleTime:       defaultMaxIdleTime,
 		IdleCheckInterval: defaultIdleCheckInterval,
 		DefaultConnectionOptions: tchannel.ConnectionOptions{
-			SendBufferSize: defaultSendBufferSize,
+			SendBufferSize:    defaultSendBufferSize,
+			CompressionMethod: tchannel.NoCompression,
 		},
 	}
 }


### PR DESCRIPTION
Adds support for using snappy compression for tchannel connections. Requires updated `tchannel-go` and this branch pretty much only adds that as well as adds a configuration option for enabling the compression.

The changes made to `tchannel-go` are in this commit https://github.com/aiven/tchannel-go/commit/4b39a9179ae15da1242bcbca1859db4584da93fc.

The compression is enabled for a tchannel only if both endpoints support it. The dbnode server has configuration option `tchannel.compression` and if that is set to `snappy`, the listener will support snappy compressed connections. The dbnode client side always "advertises" support for snappy but the tchannel only enables it if both ends have it enabled.