### PR TITLE
Aggregator compression

### DIFF
--- a/src/aggregator/server/server.go
+++ b/src/aggregator/server/server.go
@@ -93,7 +93,7 @@ func Run(opts RunOptions) {
 			SetMetricsScope(scope.
 				SubScope("m3msg-server").
 				Tagged(map[string]string{"server": "m3msg"}))
-		m3msgServerOpts, err := cfg.M3Msg.NewServerOptions(m3msgInsrumentOpts)
+		m3msgServerOpts, err := cfg.M3Msg.NewServerOptions(m3msgInsrumentOpts, serverOptions.RWOptions())
 		if err != nil {
 			logger.Fatal("could not create m3msg server options", zap.Error(err))
 		}

--- a/src/cmd/services/m3aggregator/config/server.go
+++ b/src/cmd/services/m3aggregator/config/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3/src/metrics/encoding/protobuf"
 	"github.com/m3db/m3/src/msg/consumer"
 	"github.com/m3db/m3/src/x/instrument"
+	xio "github.com/m3db/m3/src/x/io"
 	"github.com/m3db/m3/src/x/pool"
 	"github.com/m3db/m3/src/x/retry"
 	xserver "github.com/m3db/m3/src/x/server"
@@ -46,12 +47,12 @@ type M3MsgServerConfiguration struct {
 
 // NewServerOptions creates a new set of M3Msg server options.
 func (c *M3MsgServerConfiguration) NewServerOptions(
-	instrumentOpts instrument.Options,
+	instrumentOpts instrument.Options, rwOpts xio.Options,
 ) (m3msg.Options, error) {
 	opts := m3msg.NewOptions().
 		SetInstrumentOptions(instrumentOpts).
 		SetServerOptions(c.Server.NewOptions(instrumentOpts)).
-		SetConsumerOptions(c.Consumer.NewOptions(instrumentOpts))
+		SetConsumerOptions(c.Consumer.NewOptions(instrumentOpts, rwOpts))
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}

--- a/src/cmd/services/m3coordinator/server/m3msg/config.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/config.go
@@ -51,9 +51,9 @@ func (c Configuration) NewServer(
 		iOpts.SetMetricsScope(scope.Tagged(map[string]string{
 			"component": "consumer",
 		})),
+		rwOpts,
 	)
 
-	cOpts = cOpts.SetDecoderOptions(cOpts.DecoderOptions().SetRWOptions(rwOpts))
 	h, err := c.Handler.newHandler(writeFn, cOpts, iOpts.SetMetricsScope(scope))
 	if err != nil {
 		return nil, err

--- a/src/msg/consumer/handlers_test.go
+++ b/src/msg/consumer/handlers_test.go
@@ -34,58 +34,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testOpts = []Options{testOptions(), testOptionsUsingSnappyCompression()}
+
 func TestServerWithMessageFn(t *testing.T) {
 	defer leaktest.Check(t)()
 
-	var (
-		data []string
-		wg   sync.WaitGroup
-	)
+	for _, opts := range testOpts {
+		var (
+			data []string
+			wg   sync.WaitGroup
+		)
 
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	p := NewMockMessageProcessor(ctrl)
-	p.EXPECT().Process(gomock.Any()).Do(
-		func(m Message) {
-			data = append(data, string(m.Bytes()))
-			m.Ack()
-			wg.Done()
-		},
-	).Times(2)
-	// Set a large ack buffer size to make sure the background go routine
-	// can flush it.
-	opts := testOptions().SetAckBufferSize(100)
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
+		p := NewMockMessageProcessor(ctrl)
+		p.EXPECT().Process(gomock.Any()).Do(
+			func(m Message) {
+				data = append(data, string(m.Bytes()))
+				m.Ack()
+				wg.Done()
+			},
+		).Times(2)
+		// Set a large ack buffer size to make sure the background go routine
+		// can flush it.
+		opts = opts.SetAckBufferSize(100)
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
 
-	s := server.NewServer("a", NewMessageHandler(p, opts), server.NewOptions())
-	s.Serve(l)
+		s := server.NewServer("a", NewMessageHandler(p, opts), server.NewOptions())
+		s.Serve(l)
 
-	conn, err := net.Dial("tcp", l.Addr().String())
-	require.NoError(t, err)
+		conn, err := net.Dial("tcp", l.Addr().String())
+		require.NoError(t, err)
 
-	wg.Add(1)
-	err = produce(conn, &testMsg1)
-	require.NoError(t, err)
-	wg.Add(1)
-	err = produce(conn, &testMsg2)
-	require.NoError(t, err)
+		wg.Add(1)
+		err = produce(conn, &testMsg1, opts)
+		require.NoError(t, err)
+		wg.Add(1)
+		err = produce(conn, &testMsg2, opts)
+		require.NoError(t, err)
 
-	wg.Wait()
-	require.Equal(t, string(testMsg1.Value), data[0])
-	require.Equal(t, string(testMsg2.Value), data[1])
+		wg.Wait()
+		require.Equal(t, string(testMsg1.Value), data[0])
+		require.Equal(t, string(testMsg2.Value), data[1])
 
-	var ack msgpb.Ack
-	testDecoder := proto.NewDecoder(conn, opts.DecoderOptions(), 10)
-	err = testDecoder.Decode(&ack)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(ack.Metadata))
-	require.Equal(t, testMsg1.Metadata, ack.Metadata[0])
-	require.Equal(t, testMsg2.Metadata, ack.Metadata[1])
+		var ack msgpb.Ack
+		testDecoder := proto.NewDecoder(conn, opts.DecoderOptions(), 10)
+		err = testDecoder.Decode(&ack)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(ack.Metadata))
+		require.Equal(t, testMsg1.Metadata, ack.Metadata[0])
+		require.Equal(t, testMsg2.Metadata, ack.Metadata[1])
 
-	p.EXPECT().Close()
-	s.Close()
+		p.EXPECT().Close()
+		s.Close()
+	}
 }
 
 func TestServerWithConsumeFn(t *testing.T) {
@@ -112,33 +116,35 @@ func TestServerWithConsumeFn(t *testing.T) {
 		closed = true
 	}
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
+	for _, opts := range testOpts {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
 
-	// Set a large ack buffer size to make sure the background go routine
-	// can flush it.
-	opts := testOptions().SetAckBufferSize(100)
-	s := server.NewServer("a", NewConsumerHandler(consumeFn, opts), server.NewOptions())
-	require.NoError(t, err)
-	s.Serve(l)
+		// Set a large ack buffer size to make sure the background go routine
+		// can flush it.
+		opts = opts.SetAckBufferSize(100)
+		s := server.NewServer("a", NewConsumerHandler(consumeFn, opts), server.NewOptions())
+		require.NoError(t, err)
+		s.Serve(l)
 
-	conn, err := net.Dial("tcp", l.Addr().String())
-	require.NoError(t, err)
+		conn, err := net.Dial("tcp", l.Addr().String())
+		require.NoError(t, err)
 
-	wg.Add(1)
-	err = produce(conn, &testMsg1)
-	require.NoError(t, err)
+		wg.Add(1)
+		err = produce(conn, &testMsg1, opts)
+		require.NoError(t, err)
 
-	wg.Wait()
-	require.Equal(t, testMsg1.Value, bytes)
+		wg.Wait()
+		require.Equal(t, testMsg1.Value, bytes)
 
-	var ack msgpb.Ack
-	testDecoder := proto.NewDecoder(conn, opts.DecoderOptions(), 10)
-	err = testDecoder.Decode(&ack)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(ack.Metadata))
-	require.Equal(t, testMsg1.Metadata, ack.Metadata[0])
+		var ack msgpb.Ack
+		testDecoder := proto.NewDecoder(conn, opts.DecoderOptions(), 10)
+		err = testDecoder.Decode(&ack)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(ack.Metadata))
+		require.Equal(t, testMsg1.Metadata, ack.Metadata[0])
 
-	s.Close()
-	require.True(t, closed)
+		s.Close()
+		require.True(t, closed)
+	}
 }

--- a/src/msg/consumer/options.go
+++ b/src/msg/consumer/options.go
@@ -45,6 +45,7 @@ type options struct {
 	readBufferSize   int
 	iOpts            instrument.Options
 	rwOpts           xio.Options
+	compression      xio.CompressionMethod
 }
 
 // NewOptions creates a new options.
@@ -150,4 +151,14 @@ func (opts *options) SetRWOptions(value xio.Options) Options {
 
 func (opts *options) RWOptions() xio.Options {
 	return opts.rwOpts
+}
+
+func (opts *options) SetCompression(value xio.CompressionMethod) Options {
+	o := *opts
+	o.compression = value
+	return &o
+}
+
+func (opts *options) Compression() xio.CompressionMethod {
+	return opts.compression
 }

--- a/src/msg/consumer/types.go
+++ b/src/msg/consumer/types.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/m3db/m3/src/msg/protocol/proto"
 	"github.com/m3db/m3/src/x/instrument"
+	xio "github.com/m3db/m3/src/x/io"
 )
 
 // Message carries the data that needs to be processed.
@@ -111,6 +112,10 @@ type Options interface {
 
 	// SetInstrumentOptions sets the instrument options.
 	SetInstrumentOptions(value instrument.Options) Options
+
+	SetCompression(value xio.CompressionMethod) Options
+
+	Compression() xio.CompressionMethod
 }
 
 // MessageProcessor processes the message. When a MessageProcessor was set in the

--- a/src/msg/producer/config/writer.go
+++ b/src/msg/producer/config/writer.go
@@ -40,15 +40,16 @@ import (
 
 // ConnectionConfiguration configs the connection options.
 type ConnectionConfiguration struct {
-	NumConnections  *int                 `yaml:"numConnections"`
-	DialTimeout     *time.Duration       `yaml:"dialTimeout"`
-	WriteTimeout    *time.Duration       `yaml:"writeTimeout"`
-	KeepAlivePeriod *time.Duration       `yaml:"keepAlivePeriod"`
-	ResetDelay      *time.Duration       `yaml:"resetDelay"`
-	Retry           *retry.Configuration `yaml:"retry"`
-	FlushInterval   *time.Duration       `yaml:"flushInterval"`
-	WriteBufferSize *int                 `yaml:"writeBufferSize"`
-	ReadBufferSize  *int                 `yaml:"readBufferSize"`
+	NumConnections  *int                  `yaml:"numConnections"`
+	DialTimeout     *time.Duration        `yaml:"dialTimeout"`
+	WriteTimeout    *time.Duration        `yaml:"writeTimeout"`
+	KeepAlivePeriod *time.Duration        `yaml:"keepAlivePeriod"`
+	ResetDelay      *time.Duration        `yaml:"resetDelay"`
+	Retry           *retry.Configuration  `yaml:"retry"`
+	FlushInterval   *time.Duration        `yaml:"flushInterval"`
+	WriteBufferSize *int                  `yaml:"writeBufferSize"`
+	ReadBufferSize  *int                  `yaml:"readBufferSize"`
+	Compression     xio.CompressionMethod `yaml:"compression"`
 }
 
 // NewOptions creates connection options.
@@ -81,6 +82,7 @@ func (c *ConnectionConfiguration) NewOptions(iOpts instrument.Options) writer.Co
 	if c.ReadBufferSize != nil {
 		opts = opts.SetReadBufferSize(*c.ReadBufferSize)
 	}
+	opts = opts.SetCompression(c.Compression)
 	return opts.SetInstrumentOptions(iOpts)
 }
 
@@ -178,6 +180,17 @@ func (c *WriterConfiguration) NewOptions(
 		opts = opts.SetConnectionOptions(c.Connection.NewOptions(iOpts))
 	}
 
-	opts = opts.SetDecoderOptions(opts.DecoderOptions().SetRWOptions(rwOptions))
+	// Enable compression
+	switch opts.ConnectionOptions().Compression() {
+	case xio.SnappyCompression:
+		rwOptions = rwOptions.
+			SetResettableReaderFn(xio.SnappyResettableReaderFn()).
+			SetResettableWriterFn(xio.SnappyResettableWriterFn())
+	}
+
+	opts = opts.
+		SetDecoderOptions(opts.DecoderOptions().SetRWOptions(rwOptions)).
+		SetEncoderOptions(opts.EncoderOptions().SetRWOptions(rwOptions))
+
 	return opts, nil
 }

--- a/src/msg/producer/writer/options.go
+++ b/src/msg/producer/writer/options.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3/src/msg/protocol/proto"
 	"github.com/m3db/m3/src/msg/topic"
 	"github.com/m3db/m3/src/x/instrument"
+	xio "github.com/m3db/m3/src/x/io"
 	"github.com/m3db/m3/src/x/pool"
 	"github.com/m3db/m3/src/x/retry"
 )
@@ -113,6 +114,10 @@ type ConnectionOptions interface {
 
 	// SetInstrumentOptions sets the instrument options.
 	SetInstrumentOptions(value instrument.Options) ConnectionOptions
+
+	SetCompression(value xio.CompressionMethod) ConnectionOptions
+
+	Compression() xio.CompressionMethod
 }
 
 type connectionOptions struct {
@@ -126,6 +131,7 @@ type connectionOptions struct {
 	writeBufferSize int
 	readBufferSize  int
 	iOpts           instrument.Options
+	compression     xio.CompressionMethod
 }
 
 // NewConnectionOptions creates ConnectionOptions.
@@ -241,6 +247,16 @@ func (opts *connectionOptions) InstrumentOptions() instrument.Options {
 func (opts *connectionOptions) SetInstrumentOptions(value instrument.Options) ConnectionOptions {
 	o := *opts
 	o.iOpts = value
+	return &o
+}
+
+func (opts *connectionOptions) Compression() xio.CompressionMethod {
+	return opts.compression
+}
+
+func (opts *connectionOptions) SetCompression(value xio.CompressionMethod) ConnectionOptions {
+	o := *opts
+	o.compression = value
 	return &o
 }
 

--- a/src/x/io/compression.go
+++ b/src/x/io/compression.go
@@ -1,0 +1,66 @@
+package io
+
+import (
+	"fmt"
+	"io"
+
+	snappy "github.com/golang/snappy"
+)
+
+// CompressionMethod used for the read/write buffer
+type CompressionMethod byte
+
+var validCompressionMethods = []CompressionMethod{
+	NoCompression,
+	SnappyCompression,
+}
+
+const (
+	// NoCompression means compression is disabled for the read/write buffer
+	NoCompression CompressionMethod = iota
+
+	// SnappyCompression enables snappy compression for read/write buffer
+	SnappyCompression
+)
+
+func (cm CompressionMethod) String() string {
+	switch cm {
+	case NoCompression:
+		return "none"
+	case SnappyCompression:
+		return "snappy"
+	default:
+		return ""
+	}
+}
+
+// UnmarshalYAML unmarshals compression method from YAML configuration
+func (cm *CompressionMethod) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	if err := unmarshal(&str); err != nil {
+		return err
+	}
+
+	for _, valid := range validCompressionMethods {
+		if str == valid.String() {
+			*cm = valid
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid CompressionMethod '%s' valid types are: %v", str, validCompressionMethods)
+}
+
+// SnappyResettableWriterFn returns a snappy compression enabled writer
+func SnappyResettableWriterFn() ResettableWriterFn {
+	return func(r io.Writer, opts ResettableWriterOptions) ResettableWriter {
+		return snappy.NewBufferedWriter(r)
+	}
+}
+
+// SnappyResettableReaderFn returns a snappy compression enabled reader
+func SnappyResettableReaderFn() ResettableReaderFn {
+	return func(r io.Reader, opts ResettableReaderOptions) ResettableReader {
+		return snappy.NewReader(r)
+	}
+}

--- a/src/x/server/options.go
+++ b/src/x/server/options.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/x/instrument"
+	xio "github.com/m3db/m3/src/x/io"
 	xnet "github.com/m3db/m3/src/x/net"
 	"github.com/m3db/m3/src/x/retry"
 )
@@ -79,6 +80,7 @@ type options struct {
 	tcpConnectionKeepAlive       bool
 	tcpConnectionKeepAlivePeriod time.Duration
 	listenerOpts                 xnet.ListenerOptions
+	compression                  xio.CompressionMethod
 }
 
 // NewOptions creates a new set of server options


### PR DESCRIPTION
Enables snappy compression for traffic between m3coordinator and m3aggregator when using m3msg protocol.
