### PR TITLE
Add aiven specific changes on top of upstream 1.0.0

### DIFF
--- a/config/m3db/clustered-etcd/generated.yaml
+++ b/config/m3db/clustered-etcd/generated.yaml
@@ -71,5 +71,7 @@
       "handlerPath": "/metrics"
     "samplingRate": 1
     "sanitization": "prometheus"
+  "tchannel":
+    "compression": "snappy"
   "writeNewSeriesAsync": true
   "writeNewSeriesBackoffDuration": "2ms"

--- a/config/m3db/clustered-etcd/m3dbnode.libsonnet
+++ b/config/m3db/clustered-etcd/m3dbnode.libsonnet
@@ -120,6 +120,9 @@ function(cluster, coordinator={}, db={}) {
     },
     "fs": {
       "filePathPrefix": "/var/lib/m3db"
+    },
+    "tchannel": {
+      "compression": "snappy",
     }
   } + db,
 }

--- a/config/m3db/local-etcd/generated.yaml
+++ b/config/m3db/local-etcd/generated.yaml
@@ -66,5 +66,7 @@
       "handlerPath": "/metrics"
     "samplingRate": 1
     "sanitization": "prometheus"
+  "tchannel":
+    "compression": "snappy"
   "writeNewSeriesAsync": true
   "writeNewSeriesBackoffDuration": "2ms"

--- a/config/m3db/local-etcd/m3dbnode.libsonnet
+++ b/config/m3db/local-etcd/m3dbnode.libsonnet
@@ -80,6 +80,9 @@ function(coordinator={}, db={}) {
     "fs": {
       "filePathPrefix": "/var/lib/m3db"
     },
+    "tchannel": {
+      "compression": "snappy",
+    },
     "config": {
       "service": {
         "env": "default_env",

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/RoaringBitmap/roaring v0.4.21
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/aiven/tchannel-go v1.19.0 // indirect
 	github.com/apache/thrift v0.13.0
 	github.com/apex/log v1.3.0 // indirect
 	github.com/bmatcuk/doublestar v1.3.1 // indirect
@@ -163,6 +164,9 @@ replace github.com/uber-go/atomic => github.com/uber-go/atomic v1.4.0
 // etcd 3.14.13 depends on v1.3.3, but everything before v1.3.5 has unsafe misuses, and fails hard on go 1.14
 // TODO: remove after etcd pulls in the change to a new release on 3.4 branch
 replace go.etcd.io/bbolt => go.etcd.io/bbolt v1.3.5
+
+// Aiven specific: snappy compressed branch
+replace github.com/uber/tchannel-go => github.com/aiven/tchannel-go v1.19.1-0.20200910083610-4b39a9179ae1
 
 // https://github.com/ory/dockertest/issues/212
 replace golang.org/x/sys => golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,9 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUW
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
+github.com/aiven/tchannel-go v1.19.0/go.mod h1:TjrPVutwHrlYmlScDxkGdqEpJ/+sj/qRoImjzqTqfGg=
+github.com/aiven/tchannel-go v1.19.1-0.20200910083610-4b39a9179ae1 h1:pdJyQgi14sRuEFlqmy31NjGDkW3WWkLfLeRTBzl/3ro=
+github.com/aiven/tchannel-go v1.19.1-0.20200910083610-4b39a9179ae1/go.mod h1:TjrPVutwHrlYmlScDxkGdqEpJ/+sj/qRoImjzqTqfGg=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/src/aggregator/server/server.go
+++ b/src/aggregator/server/server.go
@@ -100,7 +100,7 @@ func Run(opts RunOptions) {
 			SetMetricsScope(scope.
 				SubScope("m3msg-server").
 				Tagged(map[string]string{"server": "m3msg"}))
-		m3msgServerOpts, err := cfg.M3Msg.NewServerOptions(m3msgInsrumentOpts)
+		m3msgServerOpts, err := cfg.M3Msg.NewServerOptions(m3msgInsrumentOpts, serverOptions.RWOptions())
 		if err != nil {
 			logger.Fatal("could not create m3msg server options", zap.Error(err))
 		}

--- a/src/cmd/services/m3aggregator/config/server.go
+++ b/src/cmd/services/m3aggregator/config/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3/src/metrics/encoding/protobuf"
 	"github.com/m3db/m3/src/msg/consumer"
 	"github.com/m3db/m3/src/x/instrument"
+	xio "github.com/m3db/m3/src/x/io"
 	"github.com/m3db/m3/src/x/pool"
 	"github.com/m3db/m3/src/x/retry"
 	xserver "github.com/m3db/m3/src/x/server"
@@ -46,12 +47,12 @@ type M3MsgServerConfiguration struct {
 
 // NewServerOptions creates a new set of M3Msg server options.
 func (c *M3MsgServerConfiguration) NewServerOptions(
-	instrumentOpts instrument.Options,
+	instrumentOpts instrument.Options, rwOpts xio.Options,
 ) (m3msg.Options, error) {
 	opts := m3msg.NewOptions().
 		SetInstrumentOptions(instrumentOpts).
 		SetServerOptions(c.Server.NewOptions(instrumentOpts)).
-		SetConsumerOptions(c.Consumer.NewOptions(instrumentOpts))
+		SetConsumerOptions(c.Consumer.NewOptions(instrumentOpts, rwOpts))
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}

--- a/src/cmd/services/m3coordinator/server/m3msg/config.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/config.go
@@ -52,9 +52,9 @@ func (c Configuration) NewServer(
 		iOpts.SetMetricsScope(scope.Tagged(map[string]string{
 			"component": "consumer",
 		})),
+		rwOpts,
 	)
 
-	cOpts = cOpts.SetDecoderOptions(cOpts.DecoderOptions().SetRWOptions(rwOpts))
 	h, err := c.Handler.newHandler(writeFn, cOpts, iOpts.SetMetricsScope(scope))
 	if err != nil {
 		return nil, err

--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -39,6 +39,7 @@ import (
 	"github.com/m3db/m3/src/x/instrument"
 	xlog "github.com/m3db/m3/src/x/log"
 	"github.com/m3db/m3/src/x/opentracing"
+	"github.com/uber/tchannel-go"
 
 	"go.etcd.io/etcd/embed"
 	"go.etcd.io/etcd/pkg/transport"
@@ -771,10 +772,27 @@ func IsSeedNode(initialCluster []environment.SeedNode, hostID string) bool {
 	return false
 }
 
+type compressionMethod tchannel.CompressionMethod
+
+func (cm *compressionMethod) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	if err := unmarshal(&str); err != nil {
+		return err
+	}
+	tcm, err := tchannel.NewCompressionMethod(str)
+	if err != nil {
+		return err
+	}
+	*cm = compressionMethod(tcm)
+	return nil
+}
+
 // TChannelConfiguration holds TChannel config options.
 type TChannelConfiguration struct {
 	// MaxIdleTime is the maximum idle time.
 	MaxIdleTime time.Duration `yaml:"maxIdleTime"`
 	// IdleCheckInterval is the idle check interval.
 	IdleCheckInterval time.Duration `yaml:"idleCheckInterval"`
+	// Compression method used.
+	Compression       compressionMethod `yaml:"compression"`
 }

--- a/src/dbnode/client/options.go
+++ b/src/dbnode/client/options.go
@@ -320,7 +320,10 @@ func NewOptionsForAsyncClusters(opts Options, topoInits []topology.Initializer, 
 func defaultNewConnectionFn(
 	channelName string, address string, opts Options,
 ) (xresource.SimpleCloser, rpc.TChanNode, error) {
-	channel, err := tchannel.NewChannel(channelName, opts.ChannelOptions())
+	channelOpts := opts.ChannelOptions()
+	// Advertize snappy compression support. It gets used only if remote peer has it enabled.
+	channelOpts.DefaultConnectionOptions.CompressionMethod = tchannel.SnappyCompression
+	channel, err := tchannel.NewChannel(channelName, channelOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -684,6 +684,10 @@ func Run(runOpts RunOptions) {
 	if cfg.TChannel != nil {
 		tchannelOpts.MaxIdleTime = cfg.TChannel.MaxIdleTime
 		tchannelOpts.IdleCheckInterval = cfg.TChannel.IdleCheckInterval
+		tchannelOpts.DefaultConnectionOptions.CompressionMethod = tchannel.CompressionMethod(cfg.TChannel.Compression)
+		if tchannelOpts.DefaultConnectionOptions.CompressionMethod != tchannel.NoCompression {
+			logger.Info("tchannel has compression enabled", zap.String("compression", tchannelOpts.DefaultConnectionOptions.CompressionMethod.String()))
+		}
 	}
 	tchanOpts := ttnode.NewOptions(tchannelOpts).
 		SetInstrumentOptions(opts.InstrumentOptions())

--- a/src/dbnode/x/tchannel/options.go
+++ b/src/dbnode/x/tchannel/options.go
@@ -41,7 +41,8 @@ func NewDefaultChannelOptions() *tchannel.ChannelOptions {
 		MaxIdleTime:       defaultMaxIdleTime,
 		IdleCheckInterval: defaultIdleCheckInterval,
 		DefaultConnectionOptions: tchannel.ConnectionOptions{
-			SendBufferSize: defaultSendBufferSize,
+			SendBufferSize:    defaultSendBufferSize,
+			CompressionMethod: tchannel.NoCompression,
 		},
 	}
 }

--- a/src/msg/consumer/config.go
+++ b/src/msg/consumer/config.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/m3db/m3/src/msg/protocol/proto"
 	"github.com/m3db/m3/src/x/instrument"
+	xio "github.com/m3db/m3/src/x/io"
 	"github.com/m3db/m3/src/x/pool"
 )
 
@@ -38,6 +39,7 @@ type Configuration struct {
 	ConnectionWriteBufferSize *int                      `yaml:"connectionWriteBufferSize"`
 	ConnectionReadBufferSize  *int                      `yaml:"connectionReadBufferSize"`
 	ConnectionWriteTimeout    *time.Duration            `yaml:"connectionWriteTimeout"`
+	Compression               xio.CompressionMethod     `yaml:"compression"`
 }
 
 // MessagePoolConfiguration is the message pool configuration
@@ -70,7 +72,7 @@ func (c MessagePoolConfiguration) NewOptions(
 }
 
 // NewOptions creates consumer options.
-func (c *Configuration) NewOptions(iOpts instrument.Options) Options {
+func (c *Configuration) NewOptions(iOpts instrument.Options, rwOpts xio.Options) Options {
 	opts := NewOptions().SetInstrumentOptions(iOpts)
 	if c.Encoder != nil {
 		opts = opts.SetEncoderOptions(c.Encoder.NewOptions(iOpts))
@@ -96,5 +98,19 @@ func (c *Configuration) NewOptions(iOpts instrument.Options) Options {
 	if c.ConnectionWriteTimeout != nil {
 		opts = opts.SetConnectionWriteTimeout(*c.ConnectionWriteTimeout)
 	}
+
+	// Enable compression
+	opts = opts.SetCompression(c.Compression)
+	switch opts.Compression() {
+	case xio.SnappyCompression:
+		rwOpts = rwOpts.
+			SetResettableReaderFn(xio.SnappyResettableReaderFn()).
+			SetResettableWriterFn(xio.SnappyResettableWriterFn())
+	}
+
+	opts = opts.
+		SetDecoderOptions(opts.DecoderOptions().SetRWOptions(rwOpts)).
+		SetEncoderOptions(opts.EncoderOptions().SetRWOptions(rwOpts))
+
 	return opts
 }

--- a/src/msg/consumer/handlers_test.go
+++ b/src/msg/consumer/handlers_test.go
@@ -34,58 +34,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testOpts = []Options{testOptions(), testOptionsUsingSnappyCompression()}
+
 func TestServerWithMessageFn(t *testing.T) {
 	defer leaktest.Check(t)()
 
-	var (
-		data []string
-		wg   sync.WaitGroup
-	)
+	for _, opts := range testOpts {
+		var (
+			data []string
+			wg   sync.WaitGroup
+		)
 
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	p := NewMockMessageProcessor(ctrl)
-	p.EXPECT().Process(gomock.Any()).Do(
-		func(m Message) {
-			data = append(data, string(m.Bytes()))
-			m.Ack()
-			wg.Done()
-		},
-	).Times(2)
-	// Set a large ack buffer size to make sure the background go routine
-	// can flush it.
-	opts := testOptions().SetAckBufferSize(100)
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
+		p := NewMockMessageProcessor(ctrl)
+		p.EXPECT().Process(gomock.Any()).Do(
+			func(m Message) {
+				data = append(data, string(m.Bytes()))
+				m.Ack()
+				wg.Done()
+			},
+		).Times(2)
+		// Set a large ack buffer size to make sure the background go routine
+		// can flush it.
+		opts = opts.SetAckBufferSize(100)
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
 
-	s := server.NewServer("a", NewMessageHandler(p, opts), server.NewOptions())
-	s.Serve(l)
+		s := server.NewServer("a", NewMessageHandler(p, opts), server.NewOptions())
+		s.Serve(l)
 
-	conn, err := net.Dial("tcp", l.Addr().String())
-	require.NoError(t, err)
+		conn, err := net.Dial("tcp", l.Addr().String())
+		require.NoError(t, err)
 
-	wg.Add(1)
-	err = produce(conn, &testMsg1)
-	require.NoError(t, err)
-	wg.Add(1)
-	err = produce(conn, &testMsg2)
-	require.NoError(t, err)
+		wg.Add(1)
+		err = produce(conn, &testMsg1, opts)
+		require.NoError(t, err)
+		wg.Add(1)
+		err = produce(conn, &testMsg2, opts)
+		require.NoError(t, err)
 
-	wg.Wait()
-	require.Equal(t, string(testMsg1.Value), data[0])
-	require.Equal(t, string(testMsg2.Value), data[1])
+		wg.Wait()
+		require.Equal(t, string(testMsg1.Value), data[0])
+		require.Equal(t, string(testMsg2.Value), data[1])
 
-	var ack msgpb.Ack
-	testDecoder := proto.NewDecoder(conn, opts.DecoderOptions(), 10)
-	err = testDecoder.Decode(&ack)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(ack.Metadata))
-	require.Equal(t, testMsg1.Metadata, ack.Metadata[0])
-	require.Equal(t, testMsg2.Metadata, ack.Metadata[1])
+		var ack msgpb.Ack
+		testDecoder := proto.NewDecoder(conn, opts.DecoderOptions(), 10)
+		err = testDecoder.Decode(&ack)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(ack.Metadata))
+		require.Equal(t, testMsg1.Metadata, ack.Metadata[0])
+		require.Equal(t, testMsg2.Metadata, ack.Metadata[1])
 
-	p.EXPECT().Close()
-	s.Close()
+		p.EXPECT().Close()
+		s.Close()
+	}
 }
 
 func TestServerWithConsumeFn(t *testing.T) {
@@ -112,33 +116,35 @@ func TestServerWithConsumeFn(t *testing.T) {
 		closed = true
 	}
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
+	for _, opts := range testOpts {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
 
-	// Set a large ack buffer size to make sure the background go routine
-	// can flush it.
-	opts := testOptions().SetAckBufferSize(100)
-	s := server.NewServer("a", NewConsumerHandler(consumeFn, opts), server.NewOptions())
-	require.NoError(t, err)
-	s.Serve(l)
+		// Set a large ack buffer size to make sure the background go routine
+		// can flush it.
+		opts = opts.SetAckBufferSize(100)
+		s := server.NewServer("a", NewConsumerHandler(consumeFn, opts), server.NewOptions())
+		require.NoError(t, err)
+		s.Serve(l)
 
-	conn, err := net.Dial("tcp", l.Addr().String())
-	require.NoError(t, err)
+		conn, err := net.Dial("tcp", l.Addr().String())
+		require.NoError(t, err)
 
-	wg.Add(1)
-	err = produce(conn, &testMsg1)
-	require.NoError(t, err)
+		wg.Add(1)
+		err = produce(conn, &testMsg1, opts)
+		require.NoError(t, err)
 
-	wg.Wait()
-	require.Equal(t, testMsg1.Value, bytes)
+		wg.Wait()
+		require.Equal(t, testMsg1.Value, bytes)
 
-	var ack msgpb.Ack
-	testDecoder := proto.NewDecoder(conn, opts.DecoderOptions(), 10)
-	err = testDecoder.Decode(&ack)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(ack.Metadata))
-	require.Equal(t, testMsg1.Metadata, ack.Metadata[0])
+		var ack msgpb.Ack
+		testDecoder := proto.NewDecoder(conn, opts.DecoderOptions(), 10)
+		err = testDecoder.Decode(&ack)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(ack.Metadata))
+		require.Equal(t, testMsg1.Metadata, ack.Metadata[0])
 
-	s.Close()
-	require.True(t, closed)
+		s.Close()
+		require.True(t, closed)
+	}
 }

--- a/src/msg/consumer/options.go
+++ b/src/msg/consumer/options.go
@@ -47,6 +47,7 @@ type options struct {
 	writeTimeout     time.Duration
 	iOpts            instrument.Options
 	rwOpts           xio.Options
+	compression      xio.CompressionMethod
 }
 
 // NewOptions creates a new options.
@@ -163,4 +164,14 @@ func (opts *options) SetRWOptions(value xio.Options) Options {
 
 func (opts *options) RWOptions() xio.Options {
 	return opts.rwOpts
+}
+
+func (opts *options) SetCompression(value xio.CompressionMethod) Options {
+	o := *opts
+	o.compression = value
+	return &o
+}
+
+func (opts *options) Compression() xio.CompressionMethod {
+	return opts.compression
 }

--- a/src/msg/consumer/types.go
+++ b/src/msg/consumer/types.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/m3db/m3/src/msg/protocol/proto"
 	"github.com/m3db/m3/src/x/instrument"
+	xio "github.com/m3db/m3/src/x/io"
 )
 
 // Message carries the data that needs to be processed.
@@ -117,6 +118,10 @@ type Options interface {
 
 	// SetInstrumentOptions sets the instrument options.
 	SetInstrumentOptions(value instrument.Options) Options
+
+	SetCompression(value xio.CompressionMethod) Options
+
+	Compression() xio.CompressionMethod
 }
 
 // MessageProcessor processes the message. When a MessageProcessor was set in the

--- a/src/msg/producer/config/writer.go
+++ b/src/msg/producer/config/writer.go
@@ -40,15 +40,16 @@ import (
 
 // ConnectionConfiguration configs the connection options.
 type ConnectionConfiguration struct {
-	NumConnections  *int                 `yaml:"numConnections"`
-	DialTimeout     *time.Duration       `yaml:"dialTimeout"`
-	WriteTimeout    *time.Duration       `yaml:"writeTimeout"`
-	KeepAlivePeriod *time.Duration       `yaml:"keepAlivePeriod"`
-	ResetDelay      *time.Duration       `yaml:"resetDelay"`
-	Retry           *retry.Configuration `yaml:"retry"`
-	FlushInterval   *time.Duration       `yaml:"flushInterval"`
-	WriteBufferSize *int                 `yaml:"writeBufferSize"`
-	ReadBufferSize  *int                 `yaml:"readBufferSize"`
+	NumConnections  *int                  `yaml:"numConnections"`
+	DialTimeout     *time.Duration        `yaml:"dialTimeout"`
+	WriteTimeout    *time.Duration        `yaml:"writeTimeout"`
+	KeepAlivePeriod *time.Duration        `yaml:"keepAlivePeriod"`
+	ResetDelay      *time.Duration        `yaml:"resetDelay"`
+	Retry           *retry.Configuration  `yaml:"retry"`
+	FlushInterval   *time.Duration        `yaml:"flushInterval"`
+	WriteBufferSize *int                  `yaml:"writeBufferSize"`
+	ReadBufferSize  *int                  `yaml:"readBufferSize"`
+	Compression     xio.CompressionMethod `yaml:"compression"`
 }
 
 // NewOptions creates connection options.
@@ -81,6 +82,7 @@ func (c *ConnectionConfiguration) NewOptions(iOpts instrument.Options) writer.Co
 	if c.ReadBufferSize != nil {
 		opts = opts.SetReadBufferSize(*c.ReadBufferSize)
 	}
+	opts = opts.SetCompression(c.Compression)
 	return opts.SetInstrumentOptions(iOpts)
 }
 
@@ -178,6 +180,17 @@ func (c *WriterConfiguration) NewOptions(
 		opts = opts.SetConnectionOptions(c.Connection.NewOptions(iOpts))
 	}
 
-	opts = opts.SetDecoderOptions(opts.DecoderOptions().SetRWOptions(rwOptions))
+	// Enable compression
+	switch opts.ConnectionOptions().Compression() {
+	case xio.SnappyCompression:
+		rwOptions = rwOptions.
+			SetResettableReaderFn(xio.SnappyResettableReaderFn()).
+			SetResettableWriterFn(xio.SnappyResettableWriterFn())
+	}
+
+	opts = opts.
+		SetDecoderOptions(opts.DecoderOptions().SetRWOptions(rwOptions)).
+		SetEncoderOptions(opts.EncoderOptions().SetRWOptions(rwOptions))
+
 	return opts, nil
 }

--- a/src/msg/producer/writer/options.go
+++ b/src/msg/producer/writer/options.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3/src/msg/protocol/proto"
 	"github.com/m3db/m3/src/msg/topic"
 	"github.com/m3db/m3/src/x/instrument"
+	xio "github.com/m3db/m3/src/x/io"
 	"github.com/m3db/m3/src/x/pool"
 	"github.com/m3db/m3/src/x/retry"
 )
@@ -113,6 +114,10 @@ type ConnectionOptions interface {
 
 	// SetInstrumentOptions sets the instrument options.
 	SetInstrumentOptions(value instrument.Options) ConnectionOptions
+
+	SetCompression(value xio.CompressionMethod) ConnectionOptions
+
+	Compression() xio.CompressionMethod
 }
 
 type connectionOptions struct {
@@ -126,6 +131,7 @@ type connectionOptions struct {
 	writeBufferSize int
 	readBufferSize  int
 	iOpts           instrument.Options
+	compression     xio.CompressionMethod
 }
 
 // NewConnectionOptions creates ConnectionOptions.
@@ -241,6 +247,16 @@ func (opts *connectionOptions) InstrumentOptions() instrument.Options {
 func (opts *connectionOptions) SetInstrumentOptions(value instrument.Options) ConnectionOptions {
 	o := *opts
 	o.iOpts = value
+	return &o
+}
+
+func (opts *connectionOptions) Compression() xio.CompressionMethod {
+	return opts.compression
+}
+
+func (opts *connectionOptions) SetCompression(value xio.CompressionMethod) ConnectionOptions {
+	o := *opts
+	o.compression = value
 	return &o
 }
 

--- a/src/query/api/v1/handler/influxdb/write.go
+++ b/src/query/api/v1/handler/influxdb/write.go
@@ -158,8 +158,13 @@ func (ii *ingestIterator) Next() bool {
 				for _, tag := range ptags {
 					name := make([]byte, len(tag.Key))
 					copy(name, tag.Key)
+					// tag.Value is a sub-slice of
+					// whole http body; copy it
+					// in case ingest is delayed
+					value := make([]byte, len(tag.Value))
+					copy(value, tag.Value)
 					ii.promRewriter.rewriteLabel(name)
-					tags = tags.AddTagWithoutNormalizing(models.Tag{Name: name, Value: tag.Value})
+					tags = tags.AddTagWithoutNormalizing(models.Tag{Name: name, Value: value})
 				}
 				// sanity check no duplicate Name's;
 				// after Normalize, they are sorted so

--- a/src/query/api/v1/handler/influxdb/write.go
+++ b/src/query/api/v1/handler/influxdb/write.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/m3db/m3/src/cmd/services/m3coordinator/ingest"
@@ -349,6 +350,15 @@ func (iwh *ingestWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 		resultErr = fmt.Sprintf("%s%sbad_request_errors: count=%d, last=%s",
 			resultErr, sep, numBadRequest, lastBadRequestErr)
+		// telegraf compatibility; it checks for substrings that have to be to change its behavior. so we add the magic ones to resulterr
+		if strings.Contains(lastBadRequestErr, "Message:datapoint too far in past:") {
+			// with these responses, at least telegraf will not keep retrying which will always fail
+			if numBadRequest == len(points) {
+				resultErr = fmt.Sprintf("points beyond retention policy - %s", resultErr)
+			} else {
+				resultErr = fmt.Sprintf("partial write - %s", resultErr)
+			}
+		}
 	}
 	xhttp.WriteError(w, xhttp.NewError(errors.New(resultErr), status))
 }

--- a/src/query/api/v1/handler/prometheus/native/common.go
+++ b/src/query/api/v1/handler/prometheus/native/common.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus"
@@ -63,6 +64,17 @@ func parseTime(r *http.Request, key string, now time.Time) (time.Time, error) {
 		return util.ParseTimeString(t)
 	}
 	return time.Time{}, errors.ErrNotFound
+}
+
+func shortDur(d time.Duration) string {
+	s := d.String()
+	if strings.HasSuffix(s, "m0s") {
+		s = s[:len(s)-2]
+	}
+	if strings.HasSuffix(s, "h0m") {
+		s = s[:len(s)-2]
+	}
+	return s
 }
 
 // parseParams parses all params from the GET request
@@ -126,6 +138,19 @@ func parseParams(
 		return params, xerrors.NewInvalidParamsError(
 			fmt.Errorf(formatErrStr, queryParam, err))
 	}
+
+	params.LookbackDuration = engineOpts.LookbackDuration()
+	if v := fetchOpts.LookbackDuration; v != nil {
+		params.LookbackDuration = *v
+	}
+
+	// Grafana lack of alert rule template variable expansion handling here (sigh)
+	// https://github.com/grafana/grafana/issues/6557
+	query = strings.ReplaceAll(query, "$__interval", shortDur(params.Step))
+	query = strings.ReplaceAll(query, "$__range", shortDur(params.LookbackDuration))
+	// Grafana 7.2 adds $__rate_interval which is still not expanded in alerting. According to documentation it is <= 4x step
+	query = strings.ReplaceAll(query, "$__rate_interval", shortDur(time.Duration(4)*params.Step))
+
 	params.Query = query
 
 	if debugVal := r.FormValue(debugParam); debugVal != "" {
@@ -166,11 +191,6 @@ func parseParams(
 		}
 
 		params.IncludeEnd = !excludeEnd
-	}
-
-	params.LookbackDuration = engineOpts.LookbackDuration()
-	if v := fetchOpts.LookbackDuration; v != nil {
-		params.LookbackDuration = *v
 	}
 
 	return params, nil

--- a/src/query/api/v1/handler/prometheus/native/common_test.go
+++ b/src/query/api/v1/handler/prometheus/native/common_test.go
@@ -22,6 +22,7 @@ package native
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -86,6 +87,41 @@ func TestParamParsing(t *testing.T) {
 	r, err := testParseParams(req)
 	require.Nil(t, err, "unable to parse request")
 	require.Equal(t, promQuery, r.Query)
+}
+
+func TestParamParsingGrafana(t *testing.T) {
+	t.Run("$__interval", func(t *testing.T) {
+		req := httptest.NewRequest("GET", PromReadURL, nil)
+		params := defaultParams()
+		params.Set(queryParam, fmt.Sprintf("rate(%s)[$__interval]", promQuery))
+		req.URL.RawQuery = params.Encode()
+
+		r, err := testParseParams(req)
+		require.Nil(t, err, "unable to parse request")
+		require.Equal(t, fmt.Sprintf("rate(%s)[10s]", promQuery), r.Query)
+	})
+
+	t.Run("$__rate_interval", func(t *testing.T) {
+		req := httptest.NewRequest("GET", PromReadURL, nil)
+		params := defaultParams()
+		params.Set(queryParam, fmt.Sprintf("rate(%s)[$__rate_interval]", promQuery))
+		req.URL.RawQuery = params.Encode()
+
+		r, err := testParseParams(req)
+		require.Nil(t, err, "unable to parse request")
+		require.Equal(t, fmt.Sprintf("rate(%s)[40s]", promQuery), r.Query)
+	})
+
+	t.Run("$__range", func(t *testing.T) {
+		req := httptest.NewRequest("GET", PromReadURL, nil)
+		params := defaultParams()
+		params.Set(queryParam, fmt.Sprintf("%s[$__range]", promQuery))
+		req.URL.RawQuery = params.Encode()
+
+		r, err := testParseParams(req)
+		require.Nil(t, err, "unable to parse request")
+		require.Equal(t, fmt.Sprintf("%s[0s]", promQuery), r.Query)
+	})
 }
 
 func TestParamParsing_POST(t *testing.T) {

--- a/src/x/io/compression.go
+++ b/src/x/io/compression.go
@@ -1,0 +1,66 @@
+package io
+
+import (
+	"fmt"
+	"io"
+
+	snappy "github.com/golang/snappy"
+)
+
+// CompressionMethod used for the read/write buffer
+type CompressionMethod byte
+
+var validCompressionMethods = []CompressionMethod{
+	NoCompression,
+	SnappyCompression,
+}
+
+const (
+	// NoCompression means compression is disabled for the read/write buffer
+	NoCompression CompressionMethod = iota
+
+	// SnappyCompression enables snappy compression for read/write buffer
+	SnappyCompression
+)
+
+func (cm CompressionMethod) String() string {
+	switch cm {
+	case NoCompression:
+		return "none"
+	case SnappyCompression:
+		return "snappy"
+	default:
+		return ""
+	}
+}
+
+// UnmarshalYAML unmarshals compression method from YAML configuration
+func (cm *CompressionMethod) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	if err := unmarshal(&str); err != nil {
+		return err
+	}
+
+	for _, valid := range validCompressionMethods {
+		if str == valid.String() {
+			*cm = valid
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid CompressionMethod '%s' valid types are: %v", str, validCompressionMethods)
+}
+
+// SnappyResettableWriterFn returns a snappy compression enabled writer
+func SnappyResettableWriterFn() ResettableWriterFn {
+	return func(r io.Writer, opts ResettableWriterOptions) ResettableWriter {
+		return snappy.NewBufferedWriter(r)
+	}
+}
+
+// SnappyResettableReaderFn returns a snappy compression enabled reader
+func SnappyResettableReaderFn() ResettableReaderFn {
+	return func(r io.Reader, opts ResettableReaderOptions) ResettableReader {
+		return snappy.NewReader(r)
+	}
+}

--- a/src/x/pool/config.go
+++ b/src/x/pool/config.go
@@ -35,7 +35,7 @@ type ObjectPoolConfiguration struct {
 func (c *ObjectPoolConfiguration) NewObjectPoolOptions(
 	instrumentOpts instrument.Options,
 ) ObjectPoolOptions {
-	size := defaultSize
+	size := getDefaultSize()
 	if c.Size != 0 {
 		size = c.Size
 	}

--- a/src/x/server/options.go
+++ b/src/x/server/options.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/x/instrument"
+	xio "github.com/m3db/m3/src/x/io"
 	xnet "github.com/m3db/m3/src/x/net"
 	"github.com/m3db/m3/src/x/retry"
 )
@@ -79,6 +80,7 @@ type options struct {
 	tcpConnectionKeepAlive       bool
 	tcpConnectionKeepAlivePeriod time.Duration
 	listenerOpts                 xnet.ListenerOptions
+	compression                  xio.CompressionMethod
 }
 
 // NewOptions creates a new set of server options


### PR DESCRIPTION
Combined the Grafana templating value replacement changes into one commit. Otherwise just cherry-picked the necessary commits from `aiven-0.15.0` branch.