### PR TITLE
[query] influxdb write handles empty request body

### DIFF
--- a/src/query/api/v1/handler/influxdb/write.go
+++ b/src/query/api/v1/handler/influxdb/write.go
@@ -289,8 +289,14 @@ func NewInfluxWriterHandler(options options.HandlerOptions) http.Handler {
 }
 
 func (iwh *ingestWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Body == http.NoBody {
+		xhttp.WriteError(w, xhttp.NewError(errors.New("empty request body"), http.StatusBadRequest))
+		return
+	}
+
 	var bytes []byte
 	var err error
+
 	if r.Header.Get("Content-Encoding") == "gzip" {
 		gz, err := gzip.NewReader(r.Body)
 		if err != nil {
@@ -306,6 +312,7 @@ func (iwh *ingestWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		xhttp.WriteError(w, err)
 		return
 	}
+
 	points, err := imodels.ParsePoints(bytes)
 	if err != nil {
 		xhttp.WriteError(w, err)

--- a/src/query/api/v1/httpd/handler_test.go
+++ b/src/query/api/v1/httpd/handler_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/m3db/m3/src/cmd/services/m3coordinator/ingest"
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
+	"github.com/m3db/m3/src/query/api/v1/handler/influxdb"
 	m3json "github.com/m3db/m3/src/query/api/v1/handler/json"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/handleroptions"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/native"
@@ -214,6 +215,19 @@ func TestPromNativeReadPost(t *testing.T) {
 
 func TestJSONWritePost(t *testing.T) {
 	req := httptest.NewRequest("POST", m3json.WriteJSONURL, nil)
+	res := httptest.NewRecorder()
+	ctrl := gomock.NewController(t)
+	storage, _ := m3.NewStorageAndSession(t, ctrl)
+
+	h, err := setupHandler(storage)
+	require.NoError(t, err, "unable to setup handler")
+	h.RegisterRoutes()
+	h.Router().ServeHTTP(res, req)
+	require.Equal(t, http.StatusBadRequest, res.Code, "Empty request")
+}
+
+func TestInfluxDBWritePost(t *testing.T) {
+	req := httptest.NewRequest(influxdb.InfluxWriteHTTPMethod, influxdb.InfluxWriteURL, nil)
 	res := httptest.NewRecorder()
 	ctrl := gomock.NewController(t)
 	storage, _ := m3.NewStorageAndSession(t, ctrl)


### PR DESCRIPTION
Sending a HTTP POST request without body causes internal server error.